### PR TITLE
feat(comments): WS realtime with Redis cache and configurable persist…

### DIFF
--- a/comments-service/package.json
+++ b/comments-service/package.json
@@ -12,15 +12,19 @@
     "prisma:deploy": "prisma migrate deploy"
   },
   "dependencies": {
+    "@hono/node-server": "^1.13.5",
+    "@hono/node-ws": "^1.2.0",
     "@prisma/client": "^5.16.2",
     "dotenv": "^16.4.5",
-    "hono": "^4.6.8",
-    "@hono/node-server": "^1.13.5",
+    "hono": "^4.9.0",
+    "ioredis": "^5.7.0",
+    "ws": "^8.18.3",
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "prisma": "^5.16.2",
     "@types/node": "^20.14.12",
+    "@types/ws": "^8.18.1",
+    "prisma": "^5.16.2",
     "tsx": "^4.19.2",
     "typescript": "^5.6.3"
   }

--- a/comments-service/pnpm-lock.yaml
+++ b/comments-service/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.13.5
         version: 1.18.1(hono@4.9.0)
+      '@hono/node-ws':
+        specifier: ^1.2.0
+        version: 1.2.0(@hono/node-server@1.18.1(hono@4.9.0))(hono@4.9.0)
       '@prisma/client':
         specifier: ^5.16.2
         version: 5.22.0(prisma@5.22.0)
@@ -18,8 +21,14 @@ importers:
         specifier: ^16.4.5
         version: 16.6.1
       hono:
-        specifier: ^4.6.8
+        specifier: ^4.9.0
         version: 4.9.0
+      ioredis:
+        specifier: ^5.7.0
+        version: 5.7.0
+      ws:
+        specifier: ^8.18.3
+        version: 8.18.3
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -27,6 +36,9 @@ importers:
       '@types/node':
         specifier: ^20.14.12
         version: 20.19.10
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       prisma:
         specifier: ^5.16.2
         version: 5.22.0
@@ -201,6 +213,16 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@hono/node-ws@1.2.0':
+    resolution: {integrity: sha512-OBPQ8OSHBw29mj00wT/xGYtB6HY54j0fNSdVZ7gZM3TUeq0So11GXaWtFf1xWxQNfumKIsj0wRuLKWfVsO5GgQ==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      '@hono/node-server': ^1.11.1
+      hono: ^4.6.0
+
+  '@ioredis/commands@1.3.0':
+    resolution: {integrity: sha512-M/T6Zewn7sDaBQEqIZ8Rb+i9y8qfGmq+5SDFSf9sA2lUZTmdDLVdOiQaeDp+Q4wElZ9HG1GAX5KhDaidp6LQsQ==}
+
   '@prisma/client@5.22.0':
     resolution: {integrity: sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==}
     engines: {node: '>=16.13'}
@@ -228,6 +250,26 @@ packages:
   '@types/node@20.19.10':
     resolution: {integrity: sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
+  debug@4.4.1:
+    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
@@ -249,13 +291,37 @@ packages:
     resolution: {integrity: sha512-JAUc4Sqi3lhby2imRL/67LMcJFKiCu7ZKghM7iwvltVZzxEC5bVJCsAa4NTnSfmWGb+N2eOVtFE586R+K3fejA==}
     engines: {node: '>=16.9.0'}
 
+  ioredis@5.7.0:
+    resolution: {integrity: sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==}
+    engines: {node: '>=12.22.0'}
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   prisma@5.22.0:
     resolution: {integrity: sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==}
     engines: {node: '>=16.13'}
     hasBin: true
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   tsx@4.20.3:
     resolution: {integrity: sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==}
@@ -269,6 +335,18 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -357,6 +435,17 @@ snapshots:
     dependencies:
       hono: 4.9.0
 
+  '@hono/node-ws@1.2.0(@hono/node-server@1.18.1(hono@4.9.0))(hono@4.9.0)':
+    dependencies:
+      '@hono/node-server': 1.18.1(hono@4.9.0)
+      hono: 4.9.0
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@ioredis/commands@1.3.0': {}
+
   '@prisma/client@5.22.0(prisma@5.22.0)':
     optionalDependencies:
       prisma: 5.22.0
@@ -385,6 +474,18 @@ snapshots:
   '@types/node@20.19.10':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.10
+
+  cluster-key-slot@1.1.2: {}
+
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
+  denque@2.1.0: {}
 
   dotenv@16.6.1: {}
 
@@ -426,13 +527,41 @@ snapshots:
 
   hono@4.9.0: {}
 
+  ioredis@5.7.0:
+    dependencies:
+      '@ioredis/commands': 1.3.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.1
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
+
+  ms@2.1.3: {}
+
   prisma@5.22.0:
     dependencies:
       '@prisma/engines': 5.22.0
     optionalDependencies:
       fsevents: 2.3.3
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   resolve-pkg-maps@1.0.0: {}
+
+  standard-as-callback@2.1.0: {}
 
   tsx@4.20.3:
     dependencies:
@@ -444,5 +573,7 @@ snapshots:
   typescript@5.9.2: {}
 
   undici-types@6.21.0: {}
+
+  ws@8.18.3: {}
 
   zod@3.25.76: {}

--- a/comments-service/src/index.ts
+++ b/comments-service/src/index.ts
@@ -3,6 +3,14 @@ import { serve } from '@hono/node-server';
 import { PrismaClient } from '@prisma/client';
 import { z } from 'zod';
 import 'dotenv/config';
+import { EventEmitter } from 'events';
+import { randomUUID } from 'crypto';
+import { WebSocketServer } from 'ws';
+import Redis from 'ioredis';
+// Fallback type for ws when @types/ws is not installed
+type WS = any;
+
+// Use official ioredis import and Upstash rediss URL
 
 const prisma = new PrismaClient();
 const app = new Hono();
@@ -11,7 +19,7 @@ const app = new Hono();
 const allowedOrigin = process.env.ALLOWED_ORIGIN || '*';
 app.use('*', async (c, next) => {
   c.header('Access-Control-Allow-Origin', allowedOrigin);
-  c.header('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  c.header('Access-Control-Allow-Methods', 'GET,POST,DELETE,OPTIONS');
   c.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
   if (c.req.method === 'OPTIONS') return c.body(null, 204);
   await next();
@@ -24,11 +32,20 @@ app.get('/health', (c) => c.json({ ok: true }));
 app.get('/comments', async (c) => {
   const videoId = c.req.query('videoId');
   if (!videoId) return c.json({ error: 'videoId required' }, 400);
-  const items = await prisma.comment.findMany({
-    where: { videoId },
-    orderBy: { createdAt: 'asc' },
-  });
-  return c.json({ items });
+  const limitRaw = c.req.query('limit');
+  const limit = Math.min(Math.max(Number(limitRaw || 0) || 0, 0), 1000) || 200;
+  const key = `chat:${videoId}`;
+  if (redisPublisher) {
+    try {
+      const arr = await redisPublisher.lrange(key, 0, limit - 1);
+      if (Array.isArray(arr) && arr.length > 0) {
+        const parsed = arr.map((s: string) => { try { return JSON.parse(s); } catch { return null; } }).filter(Boolean);
+        return c.json({ items: parsed.reverse() });
+      }
+    } catch { }
+  }
+  const itemsDesc = await prisma.comment.findMany({ where: { videoId }, take: limit, orderBy: { createdAt: 'desc' } });
+  return c.json({ items: itemsDesc.reverse() });
 });
 
 // Create a comment
@@ -37,20 +54,164 @@ const createSchema = z.object({
   userId: z.string().min(1),
   content: z.string().min(1).max(2000),
 });
+const PERSIST_MODE = (process.env.COMMENTS_PERSIST || 'none').toLowerCase(); // none|sample|flagged|all
+const SAMPLE_RATE = Math.min(Math.max(Number(process.env.SAMPLE_RATE || '0') || 0, 0), 1);
 
 app.post('/comments', async (c) => {
   const body = await c.req.json().catch(() => ({}));
   const parsed = createSchema.safeParse(body);
   if (!parsed.success) return c.json({ error: 'invalid body', details: parsed.error.flatten() }, 400);
   const { videoId, userId, content } = parsed.data;
-  const created = await prisma.comment.create({ data: { videoId, userId, content } });
+  // Generate lightweight object first
+  const now = new Date().toISOString();
+  const temp = { id: randomUUID(), videoId, userId, content, createdAt: now };
+  let created = temp as any;
+  // Decide persistence policy
+  const shouldPersist = PERSIST_MODE === 'all' || (PERSIST_MODE === 'sample' && Math.random() < SAMPLE_RATE);
+  if (shouldPersist) {
+    try { created = await prisma.comment.create({ data: { videoId, userId, content } }); } catch (e) { /* eslint-disable-next-line no-console */ console.error('[db] persist failed:', e instanceof Error ? e.message : e); }
+  }
+  // Broadcast immediately to ensure UX first
+  publish(String(videoId), { type: 'comment', item: created });
+  // Offload Redis cache write to next tick to avoid blocking
+  if (redisPublisher) {
+    setImmediate(async () => {
+      try {
+        const key = `chat:${videoId}`;
+        await redisPublisher.lpush(key, JSON.stringify(created));
+        await redisPublisher.ltrim(key, 0, 499);
+        await redisPublisher.expire(key, 24 * 60 * 60);
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error('[redis] cache write failed:', e instanceof Error ? e.message : e);
+      }
+    });
+  }
   return c.json(created);
+});
+
+// --- Realtime: WS + Pub/Sub (Redis optional) ---
+const localBus = new EventEmitter();
+const REDIS_URL = process.env.REDIS_URL || process.env.UPSTASH_REDIS_REST_URL || '';
+const redisPublisher = REDIS_URL ? new Redis(REDIS_URL) : null;
+
+function publish(roomId: string, payload: any) {
+  const text = typeof payload === 'string' ? payload : JSON.stringify(payload);
+  if (redisPublisher) redisPublisher.publish(`room:${roomId}`, text).catch(() => { });
+  // local fall-back
+  setImmediate(() => localBus.emit(`room:${roomId}`, text));
+}
+
+// --- WS server on separate port ---
+const wsPort = Number(process.env.COMMENTS_WS_PORT || 4002);
+const wss = new WebSocketServer({ port: wsPort, clientTracking: true });
+const roomSubscribers = new Map<string, Set<WS>>();
+const redisSubscriber = REDIS_URL ? new Redis(REDIS_URL) : null;
+if (redisPublisher) {
+  redisPublisher.on('error', (err) => {
+    // eslint-disable-next-line no-console
+    console.error('[redis] publisher error:', err?.message || err);
+  });
+}
+if (redisSubscriber) {
+  redisSubscriber.on('error', (err) => {
+    // eslint-disable-next-line no-console
+    console.error('[redis] subscriber error:', err?.message || err);
+  });
+}
+
+if (redisSubscriber) {
+  redisSubscriber.on('message', (channel: string, message: string) => {
+    localBus.emit(channel, message);
+  });
+}
+
+// Debug endpoint to verify Redis connectivity
+app.get('/debug/redis', async (c) => {
+  try {
+    const ok = !!redisPublisher;
+    const pong = redisPublisher ? await redisPublisher.ping() : null;
+    return c.json({ ok, pong, url: REDIS_URL ? 'set' : 'unset' });
+  } catch (e) {
+    return c.json({ ok: false, error: e instanceof Error ? e.message : String(e) }, 500);
+  }
+});
+
+function ensureSubscribeRoom(roomId: string) {
+  const channel = `room:${roomId}`;
+  if (redisSubscriber) {
+    // subscribe once per room
+    if (!roomSubscribers.has(roomId)) {
+      redisSubscriber.subscribe(channel).catch(() => { });
+    }
+  }
+}
+
+wss.on('connection', (ws: WS, req: any) => {
+  try {
+    const url = new URL(req.url || '/', 'http://localhost');
+    const roomId = url.searchParams.get('roomId') || '';
+    if (!roomId) { try { ws.close(); } catch { } return; }
+    const channel = `room:${roomId}`;
+
+    // track subscribers
+    if (!roomSubscribers.has(roomId)) roomSubscribers.set(roomId, new Set());
+    roomSubscribers.get(roomId)!.add(ws);
+
+    ensureSubscribeRoom(roomId);
+
+    const onLocal = (msg: string) => { try { ws.send(msg); } catch { } };
+    localBus.on(channel, onLocal);
+
+    ws.on('message', (raw: any) => {
+      try {
+        const text = typeof raw === 'string' ? raw : (raw as any).toString();
+        const data = JSON.parse(text);
+        if (data && data.type === 'comment' && data.videoId && data.userId && data.content) {
+          const content: string = String(data.content).slice(0, 2000);
+          const now = new Date().toISOString();
+          const temp = { id: randomUUID(), videoId: String(data.videoId), userId: String(data.userId), content, createdAt: now };
+          const save = async () => {
+            if (PERSIST_MODE === 'all' || (PERSIST_MODE === 'sample' && Math.random() < SAMPLE_RATE)) {
+              try { return await prisma.comment.create({ data: { videoId: String(data.videoId), userId: String(data.userId), content } }); } catch (e) { /* eslint-disable-next-line no-console */ console.error('[db] persist failed:', e instanceof Error ? e.message : e); }
+            }
+            return temp as any;
+          };
+          save().then((created) => {
+            publish(String(data.videoId), { type: 'comment', item: created });
+            if (redisPublisher) {
+              setImmediate(async () => {
+                try {
+                  const key = `chat:${created.videoId}`;
+                  await redisPublisher.lpush(key, JSON.stringify(created));
+                  await redisPublisher.ltrim(key, 0, 499);
+                  await redisPublisher.expire(key, 24 * 60 * 60);
+                } catch (e) { console.error('[redis] cache write failed:', e instanceof Error ? e.message : e); }
+              });
+            }
+          });
+        }
+      } catch { }
+    });
+
+    ws.on('close', () => {
+      localBus.off(channel, onLocal as any);
+      const set = roomSubscribers.get(roomId);
+      if (set) {
+        set.delete(ws);
+        if (set.size === 0) {
+          roomSubscribers.delete(roomId);
+          if (redisSubscriber) { try { redisSubscriber.unsubscribe(channel); } catch { } }
+        }
+      }
+    });
+  } catch { try { (ws as any).close(); } catch { } }
 });
 
 const port = Number(process.env.PORT || 4001);
 serve({ fetch: app.fetch, port }, () => {
   // eslint-disable-next-line no-console
-  console.log(`comments-service listening on http://localhost:${port}`);
+  console.log(`comments-service listening on http://localhost:${port}, ws://localhost:${wsPort}/?roomId=...`);
 });
 
 

--- a/comments-service/src/ws.d.ts
+++ b/comments-service/src/ws.d.ts
@@ -1,0 +1,1 @@
+declare module 'ws';

--- a/comments-service/tsconfig.json
+++ b/comments-service/tsconfig.json
@@ -1,15 +1,13 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
+    "target": "ES2020",
+    "module": "ESNext",
     "moduleResolution": "Node",
-    "outDir": "dist",
-    "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
…ence\n\n- WS server on port COMMENTS_WS_PORT (default 4002), room broadcast + auto reconnect client support\n- Redis: LPUSH chat:<roomId> + LTRIM 0..499 + EXPIRE 24h; Pub/Sub room:<roomId>\n- /comments GET supports ?limit and prefers Redis history\n- Persistence policy via env: COMMENTS_PERSIST=none|sample|all (default none) with SAMPLE_RATE\n- On stream ENDED: DELETE room comments and Redis list via live-service webhook\n- Add /debug/redis health endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Real-time comments via WebSocket channels with immediate broadcast on new messages.
  * Redis-backed caching for faster comment retrieval.
  * Ephemeral comment handling for quicker post responses.
  * DELETE endpoint to purge a video’s comments; automatically invoked when a stream ends.
  * Added Redis diagnostics endpoint.
  * Expanded CORS to include DELETE.
* Performance
  * Significantly reduced latency and database load for fetching recent comments through Redis.
* Chores
  * Upgraded/added runtime and type dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->